### PR TITLE
FIX: libaenet session boolean value

### DIFF
--- a/src/aenet/mlip/libaenet.py
+++ b/src/aenet/mlip/libaenet.py
@@ -513,7 +513,7 @@ def all_loaded() -> bool:
         )
 
     lib = _get_library()
-    return bool(lib.aenet_all_loaded())
+    return lib.aenet_all_loaded() != 0
 
 
 def free_atom_energy(atom_type: str) -> float:

--- a/src/aenet/mlip/libaenet.py
+++ b/src/aenet/mlip/libaenet.py
@@ -31,7 +31,7 @@ ffi.cdef("""
     void aenet_print_info(void);
     void aenet_load_potential(int type_id, char* filename, int* stat);
     void aenet_load_potential_ascii(int type_id, char* filename, int* stat);
-    _Bool aenet_all_loaded(void);
+    uint8_t aenet_all_loaded(void);
 
     double aenet_free_atom_energy(int type_id);
 


### PR DESCRIPTION
Closes #15 by letting `aenet_all_loaded(void)` be an integer instead of boolean (strictly a 0 or 1).

`aenet_all_loaded(void)` seems to not return 1 when everything is loaded and returns 255 instead.
Changing it to an integer, which will turn to True later (in `bool(lib.aenet_all_loaded())` on line 515 in [libaenet.py](https://github.com/atomisticnet/aenet-python/blob/master/src/aenet/mlip/libaenet.py) if it is not 0, seems to fix this.

Using the same structure and potential as in issue #15 shows the following output:
```python
calc = AenetCalculator(potentials)
calc._ensure_session()
> DEBUG:src.aenet.mlip.libaenet:Initializing libaenet with types: ['Au', 'Cu']
atoms.calc = calc
atoms.get_potential_energy()
> -158.6331353176941
```
This matches the value obtained from using `ANNPotential`.

However, some testing may be required to check that this does not break something else.